### PR TITLE
Logs: Fix fatal error when log file is empty

### DIFF
--- a/backend/include/Logs.php
+++ b/backend/include/Logs.php
@@ -52,6 +52,11 @@ class Logs
                 throw new AppException('Failed to read file ' . $file->getPathname());
             }
 
+            if (filesize($file->getPathname()) === 0) {
+                Output::text('File is empty. Skipping ' . $file->getPathname(), log: true);
+                continue;
+            }
+
             $contents = File::read($file->getPathname());
 
             if (preg_match($this->gzRegex, $file->getFilename())) {


### PR DESCRIPTION
Fixes fatal error thrown when a log file is empty. Empty log files are now skipped by `process()`

fixes #236 