### PR TITLE
workflow: Add missing backslash in artifact upload path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
-          path: './website'
+          path: './website/'
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
See: https://github.com/actions/upload-pages-artifact/issues/82