### PR TITLE
Config: Use system timezone for `IA_SYSTEM_LOG_TIMEZONE` if env not given

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Environment variables are used to adjust the configuration.
 
 ### GeoLite2 databases
 
-GeoLite2 databases will be automatically downloaded and updated if a [MaxMind license key](https://support.maxmind.com/hc/en-us/articles/4407111582235-Generate-a-License-Key) is set with `IA_MAXMIND_LICENSE_KEY`. 
+GeoLite2 databases will be automatically downloaded and updated if a [MaxMind license key](https://support.maxmind.com/hc/en-us/articles/4407111582235-Generate-a-License-Key) is set with `IA_MAXMIND_LICENSE_KEY`.
 
 Alternatively, the databases can be manually [downloaded](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data?lang=en) and set using the environment variables `IA_ASN_DATABASE` and `IA_COUNTRY_DATABASE`.
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Environment variables are used to adjust the configuration.
 | `IA_MAXMIND_LICENSE_KEY`| `string`  | MaxMind license key for GeoLite2 database downloads.                                                     |
 | `IA_ASN_DATABASE`       | `string`  | Path of the GeoLite2 ASN database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.               |
 | `IA_COUNTRY_DATABASE`   | `string`  | Path of the GeoLite2 Country database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.           |
-| `IA_TIMEZONE`           | `string`  | Timezone of the dashboard ([php docs](https://www.php.net/manual/en/timezones.php))                      |
-| `IA_SYSTEM_LOG_TIMEZONE`| `string`  | Timezone of fail2ban logs. <br> (optional, default timezone is UTC)                                      |
+| `IA_TIMEZONE`           | `string`  | Timezone to use in the dashboard. ([php docs](https://www.php.net/manual/en/timezones.php))              |
+| `IA_SYSTEM_LOG_TIMEZONE`| `string`  | Timezone of fail2ban logs. <br> (optional, defaults to system timezone)                                  |
 | `IA_DASH_CHARTS`        | `boolean` | Enable/disable dashboard charts. <br> (optional, charts are enabled by default)                          |
 | `IA_DASH_UPDATES`       | `boolean` | Enable/disable automatic dashboard updates. <br> (optional, updates are enabled by default)              |
 | `IA_DASH_DAEMON_LOG`    | `boolean` | Enable/disable displaying daemon log in the dashboard. <br> (optional, log viewer is enabled by default) |

--- a/backend/include/Config.php
+++ b/backend/include/Config.php
@@ -358,8 +358,6 @@ class Config
             throw new ConfigException('Unknown time zone given [IA_TIMEZONE]');
         }
 
-        date_default_timezone_set($this->getEnv('TIMEZONE'));
-
         if ($this->hasEnv('SYSTEM_LOG_TIMEZONE') === true) {
             if ($this->getEnv('SYSTEM_LOG_TIMEZONE') === '') {
                 throw new ConfigException('Time zone can not be empty [IA_SYSTEM_LOG_TIMEZONE]');
@@ -371,8 +369,10 @@ class Config
                 throw new ConfigException('Unknown time zone given [IA_SYSTEM_LOG_TIMEZONE]');
             }
         } else {
-            $this->setEnv('SYSTEM_LOG_TIMEZONE', 'UTC');
+            $this->setEnv('SYSTEM_LOG_TIMEZONE', date_default_timezone_get());
         }
+
+        date_default_timezone_set($this->getEnv('TIMEZONE'));
     }
 
     /**

--- a/backend/include/Config.php
+++ b/backend/include/Config.php
@@ -372,7 +372,7 @@ class Config
             $this->setEnv('SYSTEM_LOG_TIMEZONE', date_default_timezone_get());
         }
 
-        // date_default_timezone_set($this->getEnv('TIMEZONE'));
+        date_default_timezone_set($this->getEnv('TIMEZONE'));
     }
 
     /**

--- a/backend/include/Config.php
+++ b/backend/include/Config.php
@@ -372,7 +372,7 @@ class Config
             $this->setEnv('SYSTEM_LOG_TIMEZONE', date_default_timezone_get());
         }
 
-        date_default_timezone_set($this->getEnv('TIMEZONE'));
+        // date_default_timezone_set($this->getEnv('TIMEZONE'));
     }
 
     /**


### PR DESCRIPTION
Changes behavior of `IA_SYSTEM_LOG_TIMEZONE` so that the system timezone is used instead of UTC if the environment variable is not given.