### PR TITLE
Logs: Read log files line by line using `fgets()`

### DIFF
--- a/backend/include/Logs.php
+++ b/backend/include/Logs.php
@@ -48,10 +48,6 @@ class Logs
 
             Output::text('Processing ' . $file->getPathname(), log: true);
 
-            /*if (is_readable($file->getPathname()) === false) {
-                throw new AppException('Failed to read file ' . $file->getPathname());
-            }*/
-
             if (filesize($file->getPathname()) === 0) {
                 Output::text('File is empty. Skipping ' . $file->getPathname(), log: true);
                 continue;
@@ -63,7 +59,7 @@ class Logs
             $fp = gzopen($file->getPathname(), 'r');
 
             if ($fp === false) {
-                throw new AppException('Failed to open file ' . $file->getPathname());
+                throw new AppException('Failed to open file: ' . $file->getPathname());
             }
 
             while ($current = fgets($fp)) {

--- a/backend/include/Logs.php
+++ b/backend/include/Logs.php
@@ -48,9 +48,9 @@ class Logs
 
             Output::text('Processing ' . $file->getPathname(), log: true);
 
-            if (is_readable($file->getPathname()) === false) {
+            /*if (is_readable($file->getPathname()) === false) {
                 throw new AppException('Failed to read file ' . $file->getPathname());
-            }
+            }*/
 
             if (filesize($file->getPathname()) === 0) {
                 Output::text('File is empty. Skipping ' . $file->getPathname(), log: true);

--- a/backend/include/Logs.php
+++ b/backend/include/Logs.php
@@ -66,8 +66,8 @@ class Logs
                 throw new AppException('Failed to open file ' . $file->getPathname());
             }
 
-            while ($currentLine = fgets($fp)) {
-                $line = new LogLine($currentLine);
+            while ($current = fgets($fp)) {
+                $line = new LogLine($current);
                 $lineCount += 1;
 
                 if ($line->hasBan() === true) {

--- a/backend/tests/LogsTest.php
+++ b/backend/tests/LogsTest.php
@@ -88,16 +88,15 @@ class LogsTest extends TestCase
     }
 
     /**
-     * Test 'Failed to read file' AppException
+     * Test 'Failed to open file' AppException
      */
     public function testLogsClassWithMissingLogFile(): void
     {
         $config = $this->createConfigStub();
         $config->method('getLogPaths')->willReturn('./no-found.log');
 
-        // $this->expectOutputString("[intruder-alert] Processing ./no-found.log \n");
         $this->expectException(AppException::class);
-        $this->expectExceptionMessage('App error: Failed to read file');
+        $this->expectExceptionMessage('App error: Failed to open file');
 
         $logs = new Logs($config);
         $logs->process();


### PR DESCRIPTION
Use `gzopen()` and `fgets()` for reading log files line by line instead of loading the whole file into memory.