### PR TITLE
Require `IA_SYSTEM_LOG_TIMEZONE` when running in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,10 @@ RUN npm ci
 RUN npm run build
 
 FROM php:8.2.18-fpm-alpine3.19
+ENV IA_DOCKER=true
 
 # Install packages
- RUN apk add --no-cache \
+RUN apk add --no-cache \
   curl \
   nginx \
   supervisor

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Environment variables are used to adjust the configuration.
 | `IA_ASN_DATABASE`       | `string`  | Path of the GeoLite2 ASN database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.               |
 | `IA_COUNTRY_DATABASE`   | `string`  | Path of the GeoLite2 Country database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.           |
 | `IA_TIMEZONE`           | `string`  | Timezone to use in the dashboard. ([php docs](https://www.php.net/manual/en/timezones.php))              |
-| `IA_SYSTEM_LOG_TIMEZONE`| `string`  | Timezone of fail2ban logs. Required when using the docker image. Use the timezone of the host system.    |
+| `IA_SYSTEM_LOG_TIMEZONE`| `string`  | Timezone of fail2ban logs. Required when using the docker image.<br>Use the timezone of the host system. |
 | `IA_DASH_CHARTS`        | `boolean` | Enable/disable dashboard charts. <br> (optional, charts are enabled by default)                          |
 | `IA_DASH_UPDATES`       | `boolean` | Enable/disable automatic dashboard updates. <br> (optional, updates are enabled by default)              |
 | `IA_DASH_DAEMON_LOG`    | `boolean` | Enable/disable displaying daemon log in the dashboard. <br> (optional, log viewer is enabled by default) |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Environment variables are used to adjust the configuration.
 | `IA_ASN_DATABASE`       | `string`  | Path of the GeoLite2 ASN database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.               |
 | `IA_COUNTRY_DATABASE`   | `string`  | Path of the GeoLite2 Country database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.           |
 | `IA_TIMEZONE`           | `string`  | Timezone to use in the dashboard. ([php docs](https://www.php.net/manual/en/timezones.php))              |
-| `IA_SYSTEM_LOG_TIMEZONE`| `string`  | Timezone of fail2ban logs.<br> Required when using the docker image. Use timezone of the host system.    |
+| `IA_SYSTEM_LOG_TIMEZONE`| `string`  | Timezone of fail2ban logs. Required when using the docker image. Use the timezone of the host system.    |
 | `IA_DASH_CHARTS`        | `boolean` | Enable/disable dashboard charts. <br> (optional, charts are enabled by default)                          |
 | `IA_DASH_UPDATES`       | `boolean` | Enable/disable automatic dashboard updates. <br> (optional, updates are enabled by default)              |
 | `IA_DASH_DAEMON_LOG`    | `boolean` | Enable/disable displaying daemon log in the dashboard. <br> (optional, log viewer is enabled by default) |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Environment variables are used to adjust the configuration.
 | `IA_ASN_DATABASE`       | `string`  | Path of the GeoLite2 ASN database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.               |
 | `IA_COUNTRY_DATABASE`   | `string`  | Path of the GeoLite2 Country database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.           |
 | `IA_TIMEZONE`           | `string`  | Timezone to use in the dashboard. ([php docs](https://www.php.net/manual/en/timezones.php))              |
-| `IA_SYSTEM_LOG_TIMEZONE`| `string`  | Timezone of fail2ban logs. <br> (optional, defaults to system timezone)                                  |
+| `IA_SYSTEM_LOG_TIMEZONE`| `string`  | Timezone of fail2ban logs. Defaults to system timezone. <br> Required when using the docker image.       |
 | `IA_DASH_CHARTS`        | `boolean` | Enable/disable dashboard charts. <br> (optional, charts are enabled by default)                          |
 | `IA_DASH_UPDATES`       | `boolean` | Enable/disable automatic dashboard updates. <br> (optional, updates are enabled by default)              |
 | `IA_DASH_DAEMON_LOG`    | `boolean` | Enable/disable displaying daemon log in the dashboard. <br> (optional, log viewer is enabled by default) |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Environment variables are used to adjust the configuration.
 | `IA_ASN_DATABASE`       | `string`  | Path of the GeoLite2 ASN database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.               |
 | `IA_COUNTRY_DATABASE`   | `string`  | Path of the GeoLite2 Country database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.           |
 | `IA_TIMEZONE`           | `string`  | Timezone to use in the dashboard. ([php docs](https://www.php.net/manual/en/timezones.php))              |
-| `IA_SYSTEM_LOG_TIMEZONE`| `string`  | Timezone of fail2ban logs. Defaults to system timezone. <br> Required when using the docker image.       |
+| `IA_SYSTEM_LOG_TIMEZONE`| `string`  | Timezone of fail2ban logs.<br> Required when using the docker image. Use timezone of the host system.    |
 | `IA_DASH_CHARTS`        | `boolean` | Enable/disable dashboard charts. <br> (optional, charts are enabled by default)                          |
 | `IA_DASH_UPDATES`       | `boolean` | Enable/disable automatic dashboard updates. <br> (optional, updates are enabled by default)              |
 | `IA_DASH_DAEMON_LOG`    | `boolean` | Enable/disable displaying daemon log in the dashboard. <br> (optional, log viewer is enabled by default) |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ Environment variables are used to adjust the configuration.
 | `IA_DASH_UPDATES`       | `boolean` | Enable/disable automatic dashboard updates. <br> (optional, updates are enabled by default)              |
 | `IA_DASH_DAEMON_LOG`    | `boolean` | Enable/disable displaying daemon log in the dashboard. <br> (optional, log viewer is enabled by default) |
 
-
 ### GeoLite2 databases
 
 GeoLite2 databases will be automatically downloaded and updated if a [MaxMind license key](https://support.maxmind.com/hc/en-us/articles/4407111582235-Generate-a-License-Key) is set with `IA_MAXMIND_LICENSE_KEY`.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ services:
     container_name: intruder-alert
     environment:
       - IA_TIMEZONE=Europe/London
+      - IA_SYSTEM_LOG_TIMEZONE=UTC
       - IA_MAXMIND_LICENSE_KEY=
       - IA_LOG_FOLDER=/app/backend/data/logs
     volumes:

--- a/backend/include/Config/Check.php
+++ b/backend/include/Config/Check.php
@@ -300,7 +300,7 @@ class Check extends Base
     /**
      * Is timezone valid. Checks timezone against `DateTimeZone::listIdentifiers`
      * @param string $timezone
-     * @return bool 
+     * @return bool
      */
     protected function isTimezoneValid(string $timezone): bool
     {

--- a/backend/tests/Config/CheckTest.php
+++ b/backend/tests/Config/CheckTest.php
@@ -25,6 +25,7 @@ class CheckTest extends AbstractTestCase
     public function setUp(): void
     {
         // Unset environment variables before each test
+        putenv('IA_DOCKER');
         putenv('IA_LOG_PATHS');
         putenv('IA_LOG_FOLDER');
         putenv('IA_MAXMIND_LICENSE_KEY');
@@ -447,6 +448,20 @@ class CheckTest extends AbstractTestCase
         $config = $check->getConfig();
 
         $this->assertEquals($tz, $config['log_timezone']);
+    }
+
+    /**
+     * Test not setting `IA_SYSTEM_LOG_TIMEZONE` when running in a docker container
+     */
+    public function testNotSettingSystemLogTimezoneDocker(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Fail2ban log timezone is required when running in a docker container');
+
+        putenv('IA_DOCKER=true');
+
+        $check = new Check(self::$defaults);
+        $check->systemLogTimezone();
     }
 
     /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     container_name: intruder-alert
     environment:
       - IA_TIMEZONE=Europe/London
+      - IA_SYSTEM_LOG_TIMEZONE=UTC
       - IA_MAXMIND_LICENSE_KEY=
       - IA_LOG_FOLDER=/app/backend/data/logs
     volumes:


### PR DESCRIPTION
Updates class `Config\Check` to require env `IA_SYSTEM_LOG_TIMEZONE` when Intruder Alert is running in docker.
