### PR TITLE
Rework how `File::read()` handles file size of zero

### DIFF
--- a/backend/include/Helper/File.php
+++ b/backend/include/Helper/File.php
@@ -33,11 +33,18 @@ final class File
      *
      * @throws AppException if file was not opened.
      * @throws AppException if file was not read.
+     * @throws AppException if file is empty.
      */
     public static function read(string $path): string
     {
         $handle = File::open($path, 'r');
-        $contents = @fread($handle, (int) filesize($path));
+        $size = (int) filesize($path);
+
+        if ($size === 0) {
+            throw new AppException('File is empty: ' . $path);
+        }
+
+        $contents = @fread($handle, $size);
 
         if ($contents === false || $contents === '') {
             throw new AppException('File not read: ' . $path);

--- a/backend/tests/Helper/FileTest.php
+++ b/backend/tests/Helper/FileTest.php
@@ -34,10 +34,13 @@ class FileTest extends AbstractTestCase
     public function testOpen(): void
     {
         $file = mockfs::getUrl('/test.file');
-        file_put_contents($file, uniqid());
+
+        $data = uniqid();
+        file_put_contents($file, $data);
+        $size = strlen($data);
 
         $handler = File::open($file, 'r');
-        $contents = fread($handler, (int) filesize($file));
+        $contents = fread($handler, $size);
 
         $this->assertIsString($contents);
     }

--- a/backend/tests/Helper/FileTest.php
+++ b/backend/tests/Helper/FileTest.php
@@ -91,6 +91,20 @@ class FileTest extends AbstractTestCase
     }
 
     /**
+     * Test read() with an empty file
+     */
+    public function testReadEmptyFile(): void
+    {
+        $this->expectException(AppException::class);
+        $this->expectExceptionMessage('File is empty');
+
+        $file = mockfs::getUrl('/test.file');
+        touch($file);
+
+        File::read($file);
+    }
+
+    /**
      * Test `read()` file not read exception.
      */
     public function testReadNotReadException(): void


### PR DESCRIPTION
Reworks `File::read()` to throw an AppException when is file size is zero.