### PR TITLE
Fix action text on filter chips not changing when filters are reversed

### DIFF
--- a/frontend/js/class/Filter/Filter.js
+++ b/frontend/js/class/Filter/Filter.js
@@ -149,10 +149,7 @@ export class Filter {
         newAction = 'exclude'
       }
 
-      filter.values.forEach(value => {
-        this.chip.update(filter.type, newAction, value, filter.id)
-      })
-
+      this.chip.update(filter.id, newAction)
       this.settings[index].action = newAction
     })
   }

--- a/frontend/js/class/FilterChip.js
+++ b/frontend/js/class/FilterChip.js
@@ -47,7 +47,6 @@ export class FilterChip {
     div.appendChild(this.#createSpan(this.#typeTexts[type]))
     div.appendChild(this.#createSpan(` ${actionText} `, 'action'))
     div.appendChild(this.#createSpan(valueText, 'ellipsis'))
-    div.setAttribute('title', `${this.#typeTexts[type]} ${actionText} ${valueText}`)
 
     const item = document.createElement('div')
     item.appendChild(div)
@@ -60,20 +59,16 @@ export class FilterChip {
 
   /**
    * Update filter chip
-   * @param {string} type Filter type
-   * @param {string} action Filter action
-   * @param {string} value Filter value
    * @param {string} uuid Filter UUID
+   * @param {string} action Filter action
    */
-  update (type, action, value, uuid) {
-    const valueText = this.#getValueText(type, value)
+  update (uuid, action) {
     const actionText = this.#getActionText(action)
 
-    const div = document.querySelector(`div[data-label-id="${uuid}"]`)
-    div.setAttribute('title', `${this.#typeTexts[type]} ${actionText} ${valueText}`)
-
-    const divInner = div.childNodes[0]
-    divInner.childNodes[1].innerText = ` ${actionText} `
+    document.querySelectorAll(`div[data-label-id="${uuid}"]`).forEach(div => {
+      const divInner = div.childNodes[0]
+      divInner.childNodes[1].innerText = ` ${actionText} `
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes a bug that stops the action text on some filter chips changing to a new value when filters are reversed by the user.