### PR TITLE
Enforce strict typing

### DIFF
--- a/backend/cron.php
+++ b/backend/cron.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use IntruderAlert\Config;
 use IntruderAlert\App\Backend;
 use IntruderAlert\Helper\Output;

--- a/backend/include/App/AbstractApp.php
+++ b/backend/include/App/AbstractApp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\App;
 
 use IntruderAlert\Config;

--- a/backend/include/App/Backend.php
+++ b/backend/include/App/Backend.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\App;
 
 use DateTimeImmutable;

--- a/backend/include/App/Frontend.php
+++ b/backend/include/App/Frontend.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\App;
 
 use IntruderAlert\Helper\File;

--- a/backend/include/Cache.php
+++ b/backend/include/Cache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert;
 
 use IntruderAlert\Helper\File;

--- a/backend/include/Config.php
+++ b/backend/include/Config.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert;
 
 use IntruderAlert\Config\Check;

--- a/backend/include/Config/AbstractConfig.php
+++ b/backend/include/Config/AbstractConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Config;
 
 abstract class AbstractConfig

--- a/backend/include/Config/Check.php
+++ b/backend/include/Config/Check.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Config;
 
 use DateTimeZone;

--- a/backend/include/Database/AbstractDatabase.php
+++ b/backend/include/Database/AbstractDatabase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Database;
 
 use IntruderAlert\Logger;

--- a/backend/include/Database/Country.php
+++ b/backend/include/Database/Country.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Database;
 
 use GeoIp2\Exception\AddressNotFoundException;

--- a/backend/include/Database/Network.php
+++ b/backend/include/Database/Network.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Database;
 
 use GeoIp2\Exception\AddressNotFoundException;

--- a/backend/include/Database/Updater/Downloader.php
+++ b/backend/include/Database/Updater/Downloader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Database\Updater;
 
 use IntruderAlert\Config;

--- a/backend/include/Database/Updater/Extractor.php
+++ b/backend/include/Database/Updater/Extractor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Database\Updater;
 
 use IntruderAlert\Config;
@@ -105,9 +107,10 @@ class Extractor
             $directory = new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS);
             $items = new \RecursiveIteratorIterator($directory, \RecursiveIteratorIterator::CHILD_FIRST);
 
+            /** @var \SplFileInfo $item */
             foreach ($items as $item) {
                 if ($item->isDir() === false) {
-                    unlink($item);
+                    unlink($item->getPathname());
                 }
             }
 

--- a/backend/include/Database/Updater/TimestampFile.php
+++ b/backend/include/Database/Updater/TimestampFile.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Database\Updater;
 
 use IntruderAlert\Helper\File;

--- a/backend/include/Database/Updater/Updater.php
+++ b/backend/include/Database/Updater/Updater.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Database\Updater;
 
 use IntruderAlert\Config;

--- a/backend/include/Database/Updater/Url.php
+++ b/backend/include/Database/Updater/Url.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Database\Updater;
 
 /**

--- a/backend/include/Exception/AppException.php
+++ b/backend/include/Exception/AppException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Exception;
 
 class AppException extends \Exception

--- a/backend/include/Exception/ConfigException.php
+++ b/backend/include/Exception/ConfigException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Exception;
 
 class ConfigException extends \Exception

--- a/backend/include/Exception/FetchException.php
+++ b/backend/include/Exception/FetchException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Exception;
 
 class FetchException extends \Exception

--- a/backend/include/Exception/LogsException.php
+++ b/backend/include/Exception/LogsException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Exception;
 
 class LogsException extends \Exception

--- a/backend/include/Fetch.php
+++ b/backend/include/Fetch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert;
 
 use IntruderAlert\Exception\FetchException;

--- a/backend/include/Helper/Convert.php
+++ b/backend/include/Helper/Convert.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Helper;
 
 use DateTime;

--- a/backend/include/Helper/File.php
+++ b/backend/include/Helper/File.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Helper;
 
 use IntruderAlert\Exception\AppException;

--- a/backend/include/Helper/Json.php
+++ b/backend/include/Helper/Json.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Helper;
 
 use JsonException;

--- a/backend/include/Helper/Output.php
+++ b/backend/include/Helper/Output.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Helper;
 
 final class Output

--- a/backend/include/Helper/Timer.php
+++ b/backend/include/Helper/Timer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Helper;
 
 class Timer

--- a/backend/include/Ip.php
+++ b/backend/include/Ip.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert;
 
 class Ip

--- a/backend/include/List/AbstractList.php
+++ b/backend/include/List/AbstractList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\List;
 
 abstract class AbstractList

--- a/backend/include/List/Addresses.php
+++ b/backend/include/List/Addresses.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\List;
 
 class Addresses extends AbstractList

--- a/backend/include/List/Continents.php
+++ b/backend/include/List/Continents.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\List;
 
 class Continents extends AbstractList

--- a/backend/include/List/Countries.php
+++ b/backend/include/List/Countries.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\List;
 
 class Countries extends AbstractList

--- a/backend/include/List/Dates.php
+++ b/backend/include/List/Dates.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\List;
 
 class Dates extends AbstractList

--- a/backend/include/List/Jails.php
+++ b/backend/include/List/Jails.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\List;
 
 class Jails extends AbstractList

--- a/backend/include/List/Networks.php
+++ b/backend/include/List/Networks.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\List;
 
 class Networks extends AbstractList

--- a/backend/include/List/Subnets.php
+++ b/backend/include/List/Subnets.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\List;
 
 class Subnets extends AbstractList

--- a/backend/include/Lists.php
+++ b/backend/include/Lists.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert;
 
 use IntruderAlert\List;

--- a/backend/include/Logger.php
+++ b/backend/include/Logger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert;
 
 use DateTime;

--- a/backend/include/Logs/LineExtractor.php
+++ b/backend/include/Logs/LineExtractor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Logs;
 
 /**

--- a/backend/include/Logs/Logs.php
+++ b/backend/include/Logs/Logs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert\Logs;
 
 use IntruderAlert\Config;

--- a/backend/include/Report.php
+++ b/backend/include/Report.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert;
 
 use DateTimeZone;

--- a/backend/include/Version.php
+++ b/backend/include/Version.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace IntruderAlert;
 
 class Version

--- a/backend/tests/AbstractTestCase.php
+++ b/backend/tests/AbstractTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase as TestCase;
 use IntruderAlert\Logger;
 
@@ -29,11 +31,12 @@ abstract class AbstractTestCase extends TestCase
             $directory = new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS);
             $items = new \RecursiveIteratorIterator($directory, \RecursiveIteratorIterator::CHILD_FIRST);
 
+            /** @var SplFileInfo $item */
             foreach ($items as $item) {
                 if ($item->isDir() === true) {
-                    rmdir($item);
+                    rmdir($item->getPathname());
                 } else {
-                    unlink($item);
+                    unlink($item->getPathname());
                 }
             }
 

--- a/backend/tests/App/BackendTest.php
+++ b/backend/tests/App/BackendTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/backend/tests/App/FrontendTest.php
+++ b/backend/tests/App/FrontendTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use IntruderAlert\App\Frontend;

--- a/backend/tests/CacheTest.php
+++ b/backend/tests/CacheTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/backend/tests/Config/AbstractConfigTest.php
+++ b/backend/tests/Config/AbstractConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use IntruderAlert\Config\AbstractConfig;
 

--- a/backend/tests/Config/CheckTest.php
+++ b/backend/tests/Config/CheckTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/backend/tests/ConfigTest.php
+++ b/backend/tests/ConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/backend/tests/Database/CountryTest.php
+++ b/backend/tests/Database/CountryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use IntruderAlert\Database\Country;

--- a/backend/tests/Database/NetworkTest.php
+++ b/backend/tests/Database/NetworkTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use IntruderAlert\Database\Network;

--- a/backend/tests/Database/Updater/DownloaderTest.php
+++ b/backend/tests/Database/Updater/DownloaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/backend/tests/Database/Updater/ExtractorTest.php
+++ b/backend/tests/Database/Updater/ExtractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/backend/tests/Database/Updater/TimestampFileTest.php
+++ b/backend/tests/Database/Updater/TimestampFileTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/backend/tests/Database/Updater/UpdaterTest.php
+++ b/backend/tests/Database/Updater/UpdaterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use IntruderAlert\Database\Updater\Updater;

--- a/backend/tests/Database/Updater/UrlTest.php
+++ b/backend/tests/Database/Updater/UrlTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use IntruderAlert\Database\Updater\Url;
 

--- a/backend/tests/Exception/AppExceptionTest.php
+++ b/backend/tests/Exception/AppExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use IntruderAlert\Exception\AppException;
 

--- a/backend/tests/Exception/ConfigExceptionTest.php
+++ b/backend/tests/Exception/ConfigExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use IntruderAlert\Exception\ConfigException;
 

--- a/backend/tests/FetchTest.php
+++ b/backend/tests/FetchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use IntruderAlert\Fetch;

--- a/backend/tests/Helper/ConvertTest.php
+++ b/backend/tests/Helper/ConvertTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use IntruderAlert\Helper\Convert;
 

--- a/backend/tests/Helper/FileTest.php
+++ b/backend/tests/Helper/FileTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/backend/tests/Helper/JsonTest.php
+++ b/backend/tests/Helper/JsonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use IntruderAlert\Helper\Json;

--- a/backend/tests/Helper/OutputTest.php
+++ b/backend/tests/Helper/OutputTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use IntruderAlert\Helper\Output;
 

--- a/backend/tests/Helper/TimerTest.php
+++ b/backend/tests/Helper/TimerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use IntruderAlert\Helper\Timer;
 

--- a/backend/tests/IpTest.php
+++ b/backend/tests/IpTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use IntruderAlert\Ip;
 

--- a/backend/tests/List/AddressesTest.php
+++ b/backend/tests/List/AddressesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Depends;

--- a/backend/tests/List/ContinentsTest.php
+++ b/backend/tests/List/ContinentsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Depends;

--- a/backend/tests/List/CountriesTest.php
+++ b/backend/tests/List/CountriesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Depends;

--- a/backend/tests/List/DatesTest.php
+++ b/backend/tests/List/DatesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Depends;

--- a/backend/tests/List/JailsTest.php
+++ b/backend/tests/List/JailsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Depends;

--- a/backend/tests/List/NetworksTest.php
+++ b/backend/tests/List/NetworksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Depends;

--- a/backend/tests/List/SubnetsTest.php
+++ b/backend/tests/List/SubnetsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Depends;

--- a/backend/tests/ListsTest.php
+++ b/backend/tests/ListsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Depends;

--- a/backend/tests/LoggerTest.php
+++ b/backend/tests/LoggerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use IntruderAlert\Logger;

--- a/backend/tests/Logs/LineExtractorTest.php
+++ b/backend/tests/Logs/LineExtractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use IntruderAlert\Logs\LineExtractor;
 

--- a/backend/tests/Logs/LogsTest.php
+++ b/backend/tests/Logs/LogsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/backend/tests/ReportTest.php
+++ b/backend/tests/ReportTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use MockFileSystem\MockFileSystem as mockfs;

--- a/backend/tests/VersionTest.php
+++ b/backend/tests/VersionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use IntruderAlert\Version;
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,6 +5,11 @@
   <exclude-pattern>./coverage-reports/</exclude-pattern>
 
   <rule ref="PSR12"/>
+  <rule ref="Generic.PHP.RequireStrictTypes">
+    <exclude-pattern>./backend/tests/*</exclude-pattern>
+    <exclude-pattern>./backend/config.php</exclude-pattern>
+    <exclude-pattern>./backend/config.example.php</exclude-pattern>
+  </rule>
   <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
     <exclude-pattern>./backend/tests/*</exclude-pattern>
   </rule>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,7 +6,6 @@
 
   <rule ref="PSR12"/>
   <rule ref="Generic.PHP.RequireStrictTypes">
-    <exclude-pattern>./backend/tests/*</exclude-pattern>
     <exclude-pattern>./backend/config.php</exclude-pattern>
     <exclude-pattern>./backend/config.example.php</exclude-pattern>
   </rule>


### PR DESCRIPTION
Enforces strict typing by adding `declare(strict_types=1);` to all php files excluding `config.php` and `config.example.php`