### PR TITLE
Cache: Remove redundant if statement from `hasItem()`

### DIFF
--- a/backend/include/Cache.php
+++ b/backend/include/Cache.php
@@ -64,11 +64,7 @@ final class Cache
      */
     public function hasItem(string $ipAddress): bool
     {
-        if (array_key_exists($ipAddress, $this->data['items']) === true) {
-            return true;
-        }
-
-        return false;
+        return array_key_exists($ipAddress, $this->data['items']);
     }
 
     /**

--- a/backend/include/Cache.php
+++ b/backend/include/Cache.php
@@ -58,7 +58,7 @@ final class Cache
     }
 
     /**
-     * Returns a boolean indicating if the cache has an IP address
+     * Returns a boolean indicating cache status of an IP address
      *
      * @param string $ipAddress IP address
      */

--- a/backend/include/Cache.php
+++ b/backend/include/Cache.php
@@ -58,7 +58,7 @@ final class Cache
     }
 
     /**
-     * Check cache for IP address
+     * Returns a boolean indicating if the cache has an IP address
      *
      * @param string $ipAddress IP address
      */


### PR DESCRIPTION
Removes redundant if statement from `hasItem()` by directly returning the boolean from `array_key_exists()`.