### PR TITLE
Docker: Reduce interval between backend tasks from 600 to 300 seconds

### DIFF
--- a/docker/scripts/daemon.sh
+++ b/docker/scripts/daemon.sh
@@ -3,14 +3,14 @@
 sleep 2
 echo "Starting intruder alert daemon..."
 
-nextRun=$(bc <<< "`date '+%s'` - 600")
+nextRun=$(bc <<< "`date '+%s'` - 300")
 
 while true
 do
 	now=`date '+%s'`
 	dif=$(bc <<< "$now - $nextRun")
 
-	if [ $dif -ge 600 ]; then
+	if [ $dif -ge 300 ]; then
 		php /app/backend/cron.php
 		if [ $? -ne 0 ]; then
 			exit 1


### PR DESCRIPTION
Reduces the interval between log scanning tasks from 600 to 300 seconds when running under docker.