### PR TITLE
docker-compose: Remove security option `no-new-privileges`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ services:
       - path/to/fail2ban.log.4.gz:/app/backend/data/logs/fail2ban.log.4.gz:ro
     ports:
       - '127.0.0.1:8080:8080'
-    security_opt:
-      - no-new-privileges:true
 ```
 
 </details>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,3 @@ services:
       - path/to/fail2ban.log.4.gz:/app/backend/data/logs/fail2ban.log.4.gz:ro
     ports:
       - '127.0.0.1:8080:8080'
-    security_opt:
-      - no-new-privileges:true


### PR DESCRIPTION
Remove security option `no-new-privileges:true` from docker-compose files. See #873