### PR TITLE
Config: Require IA_SYSTEM_LOG_TIMEZONE env

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Environment variables are used to adjust the configuration.
 | `IA_ASN_DATABASE`        | `string`  | Path of the GeoLite2 ASN database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.               |
 | `IA_COUNTRY_DATABASE`    | `string`  | Path of the GeoLite2 Country database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.           |
 | `IA_TIMEZONE`            | `string`  | Timezone to use in the dashboard. ([php docs](https://www.php.net/manual/en/timezones.php))              |
-| `IA_SYSTEM_LOG_TIMEZONE` | `string`  | Timezone of fail2ban logs.                                                                               |
+| `IA_SYSTEM_LOG_TIMEZONE` | `string`  | Timezone of the host system that created the fail2ban logs.                                              |
 | `IA_VERBOSE`             | `boolean` | Enable additional logging for debugging.                                                                 |
 | `IA_DASH_CHARTS`         | `boolean` | Enable/disable dashboard charts. <br> (optional, charts are enabled by default)                          |
 | `IA_DASH_UPDATES`        | `boolean` | Enable/disable automatically updating the dashboard with new events. (optional, updates are enabled by default) |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Environment variables are used to adjust the configuration.
 | `IA_ASN_DATABASE`        | `string`  | Path of the GeoLite2 ASN database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.               |
 | `IA_COUNTRY_DATABASE`    | `string`  | Path of the GeoLite2 Country database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.           |
 | `IA_TIMEZONE`            | `string`  | Timezone to use in the dashboard. ([php docs](https://www.php.net/manual/en/timezones.php))              |
-| `IA_SYSTEM_LOG_TIMEZONE` | `string`  | Timezone of fail2ban logs. In most cases this is the timezone of the host system.                        |
+| `IA_SYSTEM_LOG_TIMEZONE` | `string`  | Timezone of fail2ban logs.                                                                               |
 | `IA_VERBOSE`             | `boolean` | Enable additional logging for debugging.                                                                 |
 | `IA_DASH_CHARTS`         | `boolean` | Enable/disable dashboard charts. <br> (optional, charts are enabled by default)                          |
 | `IA_DASH_UPDATES`        | `boolean` | Enable/disable automatically updating the dashboard with new events. (optional, updates are enabled by default) |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Environment variables are used to adjust the configuration.
 | `IA_ASN_DATABASE`        | `string`  | Path of the GeoLite2 ASN database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.               |
 | `IA_COUNTRY_DATABASE`    | `string`  | Path of the GeoLite2 Country database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.           |
 | `IA_TIMEZONE`            | `string`  | Timezone to use in the dashboard. ([php docs](https://www.php.net/manual/en/timezones.php))              |
-| `IA_SYSTEM_LOG_TIMEZONE` | `string`  | Timezone of the host system that created the fail2ban logs.                                              |
+| `IA_SYSTEM_LOG_TIMEZONE` | `string`  | Timezone of the system that created the fail2ban logs.                                                   |
 | `IA_VERBOSE`             | `boolean` | Enable additional logging for debugging.                                                                 |
 | `IA_DASH_CHARTS`         | `boolean` | Enable/disable dashboard charts. <br> (optional, charts are enabled by default)                          |
 | `IA_DASH_UPDATES`        | `boolean` | Enable/disable automatically updating the dashboard with new events. (optional, updates are enabled by default) |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Environment variables are used to adjust the configuration.
 | `IA_ASN_DATABASE`        | `string`  | Path of the GeoLite2 ASN database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.               |
 | `IA_COUNTRY_DATABASE`    | `string`  | Path of the GeoLite2 Country database file. <br> Ignored when `IA_MAXMIND_LICENSE_KEY` is set.           |
 | `IA_TIMEZONE`            | `string`  | Timezone to use in the dashboard. ([php docs](https://www.php.net/manual/en/timezones.php))              |
-| `IA_SYSTEM_LOG_TIMEZONE` | `string`  | Timezone of fail2ban logs. Required when using the docker image.<br>Use the timezone of the host system. |
+| `IA_SYSTEM_LOG_TIMEZONE` | `string`  | Timezone of fail2ban logs. In most cases this is the timezone of the host system.                        |
 | `IA_VERBOSE`             | `boolean` | Enable additional logging for debugging.                                                                 |
 | `IA_DASH_CHARTS`         | `boolean` | Enable/disable dashboard charts. <br> (optional, charts are enabled by default)                          |
 | `IA_DASH_UPDATES`        | `boolean` | Enable/disable automatically updating the dashboard with new events. (optional, updates are enabled by default) |

--- a/backend/include/Config/Check.php
+++ b/backend/include/Config/Check.php
@@ -347,14 +347,14 @@ class Check extends AbstractConfig
      * Is intruder alert running in a docker container. Checks for `IA_DOCKER=true`.
      * @return bool
      */
-    protected function isDocker(): bool
+    /*protected function isDocker(): bool
     {
         if ($this->hasEnv('DOCKER') === true && $this->getEnv('DOCKER') === 'true') {
             return true;
         }
 
         return false;
-    }
+    }*/
 
     /**
      * Is timezone valid. Checks timezone against `DateTimeZone::listIdentifiers`

--- a/backend/include/Config/Check.php
+++ b/backend/include/Config/Check.php
@@ -191,31 +191,27 @@ class Check extends AbstractConfig
     /**
      * Check system log timezone (`IA_SYSTEM_LOG_TIMEZONE`)
      *
-     * @throws ConfigException if `IA_SYSTEM_LOG_TIMEZONE` is not given when running in a docker container.
+     * @throws ConfigException if `IA_SYSTEM_LOG_TIMEZONE` is not given.
      * @throws ConfigException if `IA_SYSTEM_LOG_TIMEZONE` environment variable is empty.
      * @throws ConfigException if an unknown timezone given in `IA_SYSTEM_LOG_TIMEZONE`.
      */
     public function systemLogTimezone(): void
     {
-        if ($this->isDocker() === true && $this->hasEnv('SYSTEM_LOG_TIMEZONE') === false) {
+        if ($this->hasEnv('SYSTEM_LOG_TIMEZONE') === false) {
             throw new ConfigException(
-                'Fail2ban log timezone is required when running in a docker container. [IA_SYSTEM_LOG_TIMEZONE]'
+                'Fail2ban log timezone is required [IA_SYSTEM_LOG_TIMEZONE]'
             );
         }
 
-        if ($this->hasEnv('SYSTEM_LOG_TIMEZONE') === true) {
-            if ($this->getEnv('SYSTEM_LOG_TIMEZONE') === '') {
-                throw new ConfigException('Timezone can not be empty [IA_SYSTEM_LOG_TIMEZONE]');
-            }
-
-            if ($this->isTimezoneValid($this->getEnv('SYSTEM_LOG_TIMEZONE')) === false) {
-                throw new ConfigException('Unknown timezone given [IA_SYSTEM_LOG_TIMEZONE]');
-            }
-
-            $this->config['log_timezone'] = $this->getEnv('SYSTEM_LOG_TIMEZONE');
-        } else {
-            $this->config['log_timezone'] = date_default_timezone_get();
+        if ($this->getEnv('SYSTEM_LOG_TIMEZONE') === '') {
+            throw new ConfigException('Timezone can not be empty [IA_SYSTEM_LOG_TIMEZONE]');
         }
+
+        if ($this->isTimezoneValid($this->getEnv('SYSTEM_LOG_TIMEZONE')) === false) {
+            throw new ConfigException('Unknown timezone given [IA_SYSTEM_LOG_TIMEZONE]');
+        }
+
+        $this->config['log_timezone'] = $this->getEnv('SYSTEM_LOG_TIMEZONE');
     }
 
     /**

--- a/backend/tests/Config/CheckTest.php
+++ b/backend/tests/Config/CheckTest.php
@@ -443,6 +443,18 @@ class CheckTest extends AbstractTestCase
     }
 
     /**
+     * Test `IA_SYSTEM_LOG_TIMEZONE` not set
+     */
+    public function testNoSystemLogTimezone(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Fail2ban log timezone is required');
+
+        $check = new Check(self::$defaults);
+        $check->systemLogTimezone();
+    }
+
+    /**
      * Test empty `IA_SYSTEM_LOG_TIMEZONE`
      */
     #[WithEnvironmentVariable('IA_SYSTEM_LOG_TIMEZONE', '')]
@@ -463,33 +475,6 @@ class CheckTest extends AbstractTestCase
     {
         $this->expectException(ConfigException::class);
         $this->expectExceptionMessage('Unknown timezone given [IA_SYSTEM_LOG_TIMEZONE]');
-
-        $check = new Check(self::$defaults);
-        $check->systemLogTimezone();
-    }
-
-    /**
-     * Test not setting `IA_SYSTEM_LOG_TIMEZONE`
-     */
-    public function testNotSettingSystemLogTimezone(): void
-    {
-        $tz = date_default_timezone_get();
-
-        $check = new Check(self::$defaults);
-        $check->systemLogTimezone();
-        $config = $check->getConfig();
-
-        $this->assertEquals($tz, $config['log_timezone']);
-    }
-
-    /**
-     * Test not setting `IA_SYSTEM_LOG_TIMEZONE` when running in a docker container
-     */
-    #[WithEnvironmentVariable('IA_DOCKER', 'true')]
-    public function testNotSettingSystemLogTimezoneDocker(): void
-    {
-        $this->expectException(ConfigException::class);
-        $this->expectExceptionMessage('Fail2ban log timezone is required when running in a docker container');
 
         $check = new Check(self::$defaults);
         $check->systemLogTimezone();

--- a/backend/tests/ConfigTest.php
+++ b/backend/tests/ConfigTest.php
@@ -295,15 +295,18 @@ class ConfigTest extends AbstractTestCase
     public function testCheck(): void
     {
         putenv('IA_TIMEZONE=Europe/London');
+        putenv('IA_SYSTEM_LOG_TIMEZONE=UTC');
         putenv('IA_DASH_CHARTS=true');
 
         $config = new Config();
         $config->check();
 
         $this->assertEquals('Europe/London', $config->getTimezone());
+        $this->assertEquals('UTC', $config->getSystemLogTimezone());
         $this->assertTrue($config->getChartsStatus());
 
         putenv('IA_TIMEZONE');
+        putenv('IA_SYSTEM_LOG_TIMEZONE');
         putenv('IA_DASH_CHARTS');
     }
 
@@ -314,6 +317,7 @@ class ConfigTest extends AbstractTestCase
     {
         $contents = "<?php
             putenv('IA_TIMEZONE=Europe/London');
+            putenv('IA_SYSTEM_LOG_TIMEZONE=UTC');
             putenv('IA_DASH_CHARTS=false');
         ?>";
 
@@ -325,9 +329,11 @@ class ConfigTest extends AbstractTestCase
         $config->check();
 
         $this->assertEquals('Europe/London', $config->getTimezone());
+        $this->assertEquals('UTC', $config->getSystemLogTimezone());
         $this->assertFalse($config->getChartsStatus());
 
         putenv('IA_TIMEZONE');
+        putenv('IA_SYSTEM_LOG_TIMEZONE');
         putenv('IA_DASH_CHARTS');
     }
 


### PR DESCRIPTION
Updates configuration to always require the IA_SYSTEM_LOG_TIMEZONE environment variable, since the timezone used by php might not match the host system timezone. Addresses #1096 